### PR TITLE
operand: Fix get_xtype_str

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,7 @@
-2020-03-24 William William <william@trailofbits.com>
+2020-03-31 William Woodruff <william@trailofbits.com>
+  * Fixed an incorrect function call in operand.c
+
+2020-03-24 William Woodruff <william@trailofbits.com>
   * Bumped XED submodule to 4012555
 
 2020-03-17 William Woodruff <william@trailofbits.com>

--- a/operand.c
+++ b/operand.c
@@ -62,7 +62,7 @@ static PyObject *get_xtype(operand_t *self)
 
 static PyObject *get_xtype_str(operand_t *self)
 {
-    return PyUnicode_FromString(xed_operand_xtype_enum_t2str(xed_operand_xtype(self->operand)));
+    return PyUnicode_FromString(xed_operand_element_xtype_enum_t2str(xed_operand_xtype(self->operand)));
 }
 
 static PyObject *get_width(operand_t *self)


### PR DESCRIPTION
I'm surprised this actually compiled; fixes a nonexistent function call.