### PR TITLE
instruction: Make dump_intel_format's address printing optional

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,7 @@
-2020-03-24 William William <william@trailofbits.com>
+2020-03-31 William Woodruff <william@trailofbits.com>
+  * Fixed an incorrect function call in operand.c
+
+2020-03-24 William Woodruff <william@trailofbits.com>
   * Bumped XED submodule to 4012555
 
 2020-03-17 William Woodruff <william@trailofbits.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-04-06 William Woodruff <william@trailofbits.com>
+  * Allow dump_intel_format to take a keyword argument for
+    suppressing the runtime address
+
 2020-03-24 William William <william@trailofbits.com>
   * Bumped XED submodule to 4012555
 

--- a/includes.h
+++ b/includes.h
@@ -17,9 +17,10 @@
  */
 #define M_NOARGS(x) {#x, ((PyCFunction)(x)), METH_NOARGS, NULL}
 #define M_VARARGS(x) {#x, ((PyCFunction)(x)), METH_VARARGS, NULL}
+#define M_KWARGS(x) {#x, ((PyCFunction)(x)), METH_VARARGS | METH_KEYWORDS, NULL}
 
 /* Define `M_NULL' to avoid using `{NULL}' in `PyMethodDef[]' definitions. Fixes
- * several compiler warnings about missing initializers thrown on my Mac OS X 
+ * several compiler warnings about missing initializers thrown on my Mac OS X
  * system by LLVM. According to K&R, however, using `{NULL}' is correct.
  */
 #define M_NULL {NULL, NULL, 0, NULL}

--- a/operand.c
+++ b/operand.c
@@ -62,7 +62,7 @@ static PyObject *get_xtype(operand_t *self)
 
 static PyObject *get_xtype_str(operand_t *self)
 {
-    return PyUnicode_FromString(xed_operand_xtype_enum_t2str(xed_operand_xtype(self->operand)));
+    return PyUnicode_FromString(xed_operand_element_xtype_enum_t2str(xed_operand_xtype(self->operand)));
 }
 
 static PyObject *get_width(operand_t *self)


### PR DESCRIPTION
Changes `insn.dump_intel_format()` into `insn.dump_intel_format(address=False)`, where `address` controls whether or not `runtime_address` is included in the dumped disassembly.